### PR TITLE
Uncommented deflate directives

### DIFF
--- a/template-httpd.m4
+++ b/template-httpd.m4
@@ -14,9 +14,10 @@ Listen *:xPORT
 # LoadModule proxy_ftp_module /QSYS.LIB/QHTTPSVR.LIB/QZSRCORE.SRVPGM
 # SSL/TLS (HTTPS; requires further flags to enable):
 # LoadModule ibm_ssl_module /QSYS.LIB/QHTTPSVR.LIB/QZSRVSSL.SRVPGM
-# Transparent compression (use files that aren't already compressed, like text):
-# LoadModule deflate_module /QSYS.LIB/QHTTPSVR.LIB/QZSRCORE.SRVPGM
-# AddOutputFilterByType DEFLATE application/x-httpd-php application/json text/css application/x-javascript application/javascript text/html
+
+# Transparent gzip compression (use on files that aren't already compressed, like text):
+LoadModule deflate_module /QSYS.LIB/QHTTPSVR.LIB/QZSRCORE.SRVPGM
+AddOutputFilterByType DEFLATE application/x-httpd-php application/json text/css application/x-javascript application/javascript text/html
 
 # FastCGI
 LoadModule zend_enabler_module /QSYS.LIB/QHTTPSVR.LIB/QZFAST.SRVPGM


### PR DESCRIPTION
Customers are finding CP+ not as fast as advertised if their deflate is not on.
Alan takes responsibility for this gzip being enabled out of the box.